### PR TITLE
fix: allow text and icon from baseObject when state is empty

### DIFF
--- a/src/lib/app-type/user/expert.ts
+++ b/src/lib/app-type/user/expert.ts
@@ -73,11 +73,11 @@ export namespace AppType {
 
                 const app: AwtrixApi.App = {
                     ...this.baseObject,
-                    text: typeof this.appStates.text === 'string' ? this.appStates.text : '',
+                    text: typeof this.appStates.text === 'string' && this.appStates.text !== '' ? this.appStates.text : (this.baseObject.text ?? ''),
                     textCase: 2, // show as sent
                     color: typeof this.appStates.color === 'string' ? this.appStates.color : '#FFFFFF',
                     background: typeof this.appStates.background === 'string' ? this.appStates.background : '#000000',
-                    icon: typeof this.appStates.icon === 'string' ? this.appStates.icon : '',
+                    icon: typeof this.appStates.icon === 'string' && this.appStates.icon !== '' ? this.appStates.icon : (this.baseObject.icon ?? ''),
                     duration: typeof this.appStates.duration === 'number' ? this.appStates.duration : 0,
                     scrollSpeed: typeof this.appStates.scrollSpeed === 'number' ? this.appStates.scrollSpeed : 100,
                     pos: this.appDefinition.position,


### PR DESCRIPTION
## Problem

When using expert apps with `baseObject`, the `text` and `icon` fields in `baseObject` are always overridden by the individual states — even when those states are empty strings (`''`).

This makes it impossible to use the full Awtrix3 API features via `baseObject`, specifically:
- **Colored text fragments** (`text` as an array of `{t, c}` objects)
- **Dynamic icons** set exclusively via `baseObject`

## Root cause

In `refresh()`, the individual state always wins regardless of its value:

```typescript
// before — empty string overrides baseObject
text: typeof this.appStates.text === 'string' ? this.appStates.text : '',
icon: typeof this.appStates.icon === 'string' ? this.appStates.icon : '',
```

## Fix

Fall back to `baseObject` value when the state is an empty string:

```typescript
// after — empty state lets baseObject win
text: typeof this.appStates.text === 'string' && this.appStates.text !== '' ? this.appStates.text : (this.baseObject.text ?? ''),
icon: typeof this.appStates.icon === 'string' && this.appStates.icon !== '' ? this.appStates.icon : (this.baseObject.icon ?? ''),
```

This is fully backwards-compatible: existing scripts that set the `text` or `icon` state to a non-empty value are unaffected.

## Use case example

Send colored text fragments via `baseObject`:

```json
{
  "text": [
    { "t": "21°", "c": "FF0000" },
    { "t": " 23°", "c": "FFFFFF" }
  ],
  "icon": "thermometer"
}
```